### PR TITLE
Wait for mysql:3306

### DIFF
--- a/.github/workflows/registration.yml
+++ b/.github/workflows/registration.yml
@@ -1,9 +1,9 @@
 name: Test registration process
 on:
   push:
+    branches: [ main ]
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
 
 jobs:
   test-registration-process:

--- a/.github/workflows/registration.yml
+++ b/.github/workflows/registration.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install dependencies
         run: 'docker-compose exec -T app composer install --no-interaction'
 
+      - name: Wait for MySQL server
+        run: 'docker-compose run -e WAIT_HOSTS=mysql:3306 wait-for-it'
+
       - name: Run migrations
         run: 'docker-compose exec -T app php bin/console doctrine:migrations:migrate'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,6 @@ services:
       MYSQL_USER: app
       MYSQL_PASSWORD: app
       MYSQL_ROOT_PASSWORD: root
+
+  wait-for-it:
+    image: blablalines/wait:2.6.0-slim


### PR DESCRIPTION
The MySQL container happens to not be ready sometimes. To prevent this, the workflow waits until `mysql:3306` is reachable.